### PR TITLE
Call successEntry on successful CRUD operation

### DIFF
--- a/inventory/src/controller/CtrlerInventory.java
+++ b/inventory/src/controller/CtrlerInventory.java
@@ -193,6 +193,7 @@ public class CtrlerInventory {
 
 					// Conditional scene switch if CRUD operation is a success
 					if (stateChange) {
+						view.successEntry();
 						state = "Main";
 						view.newTable(model.getItems());
 						view.swapSouthPanel();


### PR DESCRIPTION
Added a call to view.successEntry() after a successful CRUD operation in CtrlerInventory. This provides user feedback upon successful entry before updating the table and swapping the panel.